### PR TITLE
Reference patch-package within bin folder properly

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 
-# Patch installed node_modules
-patch-package
+# Patch installed within node_modules
+./node_modules/.bin/patch-package
 
 
 # `patch-package` has issues with diffing binary files so we'll fallback to just


### PR DESCRIPTION
Not every setup will have ./node_modules/.bin/ added to PATH, so reference it
relative to the project root.

---

# Reviewer considerations

I'm hoping that this may resolve some issues with others setting up the application. The best way to review this is to test it out by:

1. Pulling this down
1. Removing `node_modules` if you have it in place
1. Running `npm install`
1. Verifying that the installation process succeeded

@ericboucher mentioned that he was having trouble because `patch-package` wouldn't apply. I believe the reason for this is that `prepare.sh` wasn't referencing the path of the executable correctly. This should fix that. 

As a note, eventually we'd like to get rid of these patches by updating to newer versions of dependencies. 