### PR TITLE
fix (more-options): Fix text on more options page for iOS

### DIFF
--- a/src/shared/views/MoreOptions.js
+++ b/src/shared/views/MoreOptions.js
@@ -9,6 +9,7 @@ import {
     ScrollView,
     StyleSheet,
     Image,
+    Platform,
 } from 'react-native';
 import Button from 'apsl-react-native-button';
 import * as Progress from 'react-native-progress';
@@ -38,7 +39,7 @@ const styles = StyleSheet.create({
     otherButton: {
         width: GLOBAL.SCREEN_WIDTH,
         height: 30,
-        padding: 12,
+        padding: Platform.OS === 'ios' ? 0 : 12,
         marginTop: 10,
         borderWidth: 0,
     },


### PR DESCRIPTION
The extra padding was cutting off the text inside the buttons. This may only be happening on iOS so a check was made specifically for that platform. It may make sense to try and move to a [React Native component library](https://blog.bitsrc.io/11-react-native-component-libraries-you-should-know-in-2018-71d2a8e33312) to get the benefits from a framework that has hopefully already solved these types of issues cross-platform visual issues.

Before:
<img width="545" alt="Screen Shot 2019-06-21 at 11 21 27 AM" src="https://user-images.githubusercontent.com/7051027/59943573-70415800-9417-11e9-9801-cb97f0c56f90.png">

After:
<img width="545" alt="Screen Shot 2019-06-21 at 11 21 47 AM" src="https://user-images.githubusercontent.com/7051027/59943575-733c4880-9417-11e9-88e8-28dfebd063cb.png">


cc: @ericboucher 