### PR TITLE
Setup versioning for android

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
         - echo 'hw.lcd.height=900' >> ~/.android/avd/ci_avd.avd/config.ini
         - echo 'hw.lcd.width=500' >> ~/.android/avd/ci_avd.avd/config.ini
         - export ANDROID_EMULATOR_DEBUG=1
+        - export ADB_INSTALL_TIMEOUT=10
         - $ANDROID_HOME/emulator/emulator -version
         - $ANDROID_HOME/emulator/emulator @ci_avd -no-audio -no-window -verbose &
         - android-wait-for-emulator
@@ -117,8 +118,10 @@ matrix:
         - security unlock-keychain -p travis $KEY_CHAIN
         - security set-keychain-settings -t 3600 -u $KEY_CHAIN
         # run the detox tests
+        - cd ..
         - detox build --configuration ios.sim.debug
         - detox test --configuration ios.sim.debug --cleanup
+        - cd ios
         # The test lane refreshes the development certificates, compiles the app and launches the unit tests.
         # Actual Tests have been disabled since Travis has issues launching the simulator, but the app is being compiled.
         - bundle exec fastlane test

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,18 +60,18 @@ matrix:
         - yarn global add react-native-cli
         - yarn global add detox-cli
         - echo $ANDROID_HOME
-        # echo no | $ANDROID_HOME/tools/bin/avdmanager create avd --force -n ci_avd -k 'system-images;android-25;google_apis;armeabi-v7a' --abi armeabi-v7a -c 100M
-        #- $ANDROID_HOME/tools/bin/avdmanager list avd
+        - echo no | $ANDROID_HOME/tools/bin/avdmanager create avd --force -n ci_avd -k 'system-images;android-25;google_apis;armeabi-v7a' --abi armeabi-v7a -c 100M
+        - $ANDROID_HOME/tools/bin/avdmanager list avd
         # fix https://github.com/wix/Detox/issues/1157 with the next 2 lines
-        # echo 'hw.lcd.height=900' >> ~/.android/avd/ci_avd.avd/config.ini
-        # echo 'hw.lcd.width=500' >> ~/.android/avd/ci_avd.avd/config.ini
-        # export ANDROID_EMULATOR_DEBUG=1
-        # $ANDROID_HOME/emulator/emulator -version
-        # $ANDROID_HOME/emulator/emulator @ci_avd -no-audio -no-window -verbose &
-        # android-wait-for-emulator
-        # adb shell input keyevent 82 &
-        # detox build -c android.ci.debug
-        # detox test -c android.ci.debug --loglevel trace
+        - echo 'hw.lcd.height=900' >> ~/.android/avd/ci_avd.avd/config.ini
+        - echo 'hw.lcd.width=500' >> ~/.android/avd/ci_avd.avd/config.ini
+        - export ANDROID_EMULATOR_DEBUG=1
+        - $ANDROID_HOME/emulator/emulator -version
+        - $ANDROID_HOME/emulator/emulator @ci_avd -no-audio -no-window -verbose &
+        - android-wait-for-emulator
+        - adb shell input keyevent 82 &
+        - detox build -c android.ci.debug
+        - detox test -c android.ci.debug --loglevel trace
       script:
         - yarn buildDev
     - language: objective-c
@@ -117,8 +117,8 @@ matrix:
         - security unlock-keychain -p travis $KEY_CHAIN
         - security set-keychain-settings -t 3600 -u $KEY_CHAIN
         # run the detox tests
-        # detox build --configuration ios.sim.debug
-        # detox test --configuration ios.sim.debug --cleanup
+        - detox build --configuration ios.sim.debug
+        - detox test --configuration ios.sim.debug --cleanup
         # The test lane refreshes the development certificates, compiles the app and launches the unit tests.
         # Actual Tests have been disabled since Travis has issues launching the simulator, but the app is being compiled.
         - bundle exec fastlane test

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,14 +99,29 @@ def getNpmVersion() {
     return packageJson["version"]
 }
 
-// build an integer number to keep google happy
-def getGoogleVersion() {
-    def (major, minor, patch) = getNpmVersion().tokenize('.')
-    return Integer.parseInt(major) * 10000 + Integer.parseInt(minor) * 100 + Integer.parseInt(patch)
+def getNpmBuildNumber() {
+    def inputFile = new File("../package.json")
+    def packageJson = new JsonSlurper().parseText(inputFile.text)
+    return packageJson["build"]
 }
 
-def userVersion = getNpmVersion()
-def googleVersion = getGoogleVersion()
+// build an integer number to keep google happy
+def setGoogleVersion() {
+    def (major, minor, patch) = getNpmVersion().tokenize('.')
+    def build = getNpmBuildNumber()
+    return Integer.parseInt(major) * 1000000 + Integer.parseInt(minor) * 10000 + Integer.parseInt(patch) * 100 + Integer.parseInt(build)
+}
+
+// build a version name to show to the user
+// in the format "1.3.37 (4)"
+def setVersionName() {
+    def version = getNpmVersion()
+    def build = getNpmBuildNumber()
+    return version + " (" + build + ")"
+}
+
+def userVersion = setVersionName()
+def googleVersion = setGoogleVersion()
 
 /**
  * Set this to true to create two separate APKs instead of one:

--- a/docs/develop-android.md
+++ b/docs/develop-android.md
@@ -134,8 +134,9 @@ There are 2 sets of tests setup:
 It should all be set automatically from `package.json`. When you need to release a new version, just run:
 
 ```
-yarn version
+bash scripts/version.sh
 ```
-and input the new version number (in semantic version format). A new commit will be produced with the version number changed in `package.json`. The build scripts will take care of adjusting the builds based on this. The `yarn postversion` script will run automatically, and push the commit and new tag to github, which in turn will trigger a build on travis and deployment to github releases. (TODO: add deployment to google playstore for `ProductionRelease` version)
+and input the new version number (in semantic version format) and build number (0-99). A new commit will be produced with the version number changed in `package.json`. The build scripts will take care of adjusting the builds based on this. The script will then push the commit and new tag to github, which in turn will trigger a build on travis and deployment to github releases for android, and to testflight for iOS.
 
 For android, gradle will pull the version number from package.json when building.
+For iOS, the version numbers are in the iOS project file.

--- a/docs/develop-ios.md
+++ b/docs/develop-ios.md
@@ -67,8 +67,6 @@ $ yarn global add detox-cli
 
 See [the android page](develop-android.md#version-numbering) for details.
 
-On the iOS side, the version number is not written in files, but passed to fastlane via environment variables during the build. The variables are set from `package.json` to ensure a single source of truth, so android and iOS builds will have matching version and build numbers. See `.travis.yml` and `fastlane` files (under `ios/fastlane/`) for details.
-
 ## CI build process
 
 **Warning**: this is written as I discover the process, it may not be fully accurate, correct or optimal.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mapswipe",
   "version": "1.3.34",
+  "build": "6",
   "private": true,
   "scripts": {
     "buildDev": "cd android && ./gradlew assembleDevRelease && cd ..",

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,9 +1,42 @@
 #!/bin/bash
 
-echo -n "Version number: "
+# This script updates version and build numbers as needed for both
+# Android and iOS build systems.
+# This replaces the default `yarn version` script, which does not handle
+# build numbers as needed for iOS deployments.
+
+# The resulting git tags will look like:
+# v1.3.38(4)-beta where
+# 1.3.38 is a semver version number
+# 4 is the build number
+# all numbers above must be between 0 and 99, or the system will fail somewhere
+# -beta is only added to beta/dev builds, the production build has no extension
+
+# On android, the build.grade script will build a globally unique build number to satisfy
+# the playstore's requirements.
+# This script must be run locally (not on travis) to release a new version.
+
+# get current version/build from package.json
+current_version_number=`grep '^\ *"version":' package.json | sed 's/.*"\(.*\)",/\1/g'`
+current_build_number=`grep '^\ *"build": "[0-9]",' package.json | sed 's/.*"\(.*\)",/\1/g'`
+
+# ask for new version number, and check it's valid
+echo -n "Current version is $current_version_number. Input new version number: "
 read  versionNumber;
-echo -n "Build number: "
+semver_check="(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)"
+if [[ ! "$versionNumber" =~ $semver_check ]]; then
+    echo "Version number must be a semantic version (like 1.4.19). Exiting."
+    exit 1
+fi
+
+# ask and validate build number
+echo -n "Current build is $current_build_number. Input new build number: "
 read buildNumber;
+build_check="[0-9]"
+if [[ ! "$buildNumber" =~ $build_check ]]; then
+    echo "Build number must be a number. Exiting."
+    exit 1
+fi
 
 echo "Releasing version $versionNumber build $buildNumber"
 
@@ -17,8 +50,11 @@ echo "Release version in beta or Prod ?"
     esac
   done
 
+# update package.json with the new version and build numbers
 yarn version --new-version $versionNumber --no-git-tag-version
+sed -i -e "s/^\ *\"build\": \"[0-9]\"\,$/  \"build\": \"${buildNumber}\"\,/" package.json
 
+# update iOS specific files with the new numbers
 bundle exec fastlane run increment_build_number build_number:$buildNumber xcodeproj:ios/mapswipe.xcodeproj
 bundle exec fastlane run increment_version_number version_number:$versionNumber xcodeproj:ios/mapswipe.xcodeproj
 


### PR DESCRIPTION
The changes needed to set the version numbers for android. The script now stores the build number in `package.json` as the source of "truth" for android, and the actual numbers are generated at build time from it.
I added some checks on the numbers formatting to prevent gross mistakes (I'm not 100% sure of my regexps :scream: ).
I've not released new versions, but the build works locally, so there should be no issue on the android side in travis.
I'll let you update your PR, and when you're happy with it, we can merge into `dev`.

And updated docs as well :)