### PR TITLE
#46 Add a scalebar to built area projects

### DIFF
--- a/src/shared/common/ScaleBar.js
+++ b/src/shared/common/ScaleBar.js
@@ -1,0 +1,114 @@
+// @flow
+import * as React from 'react';
+import {
+    ART,
+    View,
+} from 'react-native';
+import GLOBAL from '../Globals';
+
+type Props = {
+    latitude: number,
+    visible: boolean,
+    zoomLevel: number,
+};
+
+const getScaleBar = (meters, feet) => {
+    /*
+     * produce a shape like
+     * |       |
+     * --------------
+     * |            |
+     */
+    const top = 0;
+    const mid = 16;
+    const bottom = top + 2 * (mid - top);
+    const p = ART.Path().moveTo(0, top);
+    p.lineTo(0, bottom);
+    p.moveTo(0, mid);
+    p.lineTo(meters, mid);
+    p.lineTo(meters, top);
+    p.moveTo(meters, mid);
+    p.lineTo(feet * 0.3048, mid);
+    p.lineTo(feet * 0.3048, bottom);
+    return p;
+};
+
+export default (props: Props) => {
+    const { latitude, visible, zoomLevel } = props;
+
+    // calculate the width of one tile (in meters)
+    // this magic formula comes from
+    // https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Resolution_and_Scale
+    const tileWidth = (Math.cos(latitude * Math.PI / 180)
+        * 2 * Math.PI * 6378137) / (256 * (2 ** zoomLevel)) * 256;
+    let feet;
+    let meters;
+    // we hardcode the scale bar sizes, and pick an appropriate one
+    // for the current zoom level
+    switch (true) {
+    case (tileWidth < 70):
+        meters = 30;
+        feet = 100;
+        break;
+    case (tileWidth < 110):
+        meters = 50;
+        feet = 200;
+        break;
+    case (tileWidth < 180):
+        meters = 100;
+        feet = 300;
+        break;
+    default:
+        meters = 200;
+        feet = 500;
+        break;
+    }
+
+    const p = getScaleBar(meters, feet);
+    return (
+        <View style={{
+            height: GLOBAL.TILE_SIZE / 5,
+            width: GLOBAL.TILE_SIZE,
+            opacity: (visible ? 0.8 : 0),
+            position: 'absolute',
+            bottom: 20,
+            left: 10,
+        }}
+        >
+            <ART.Surface
+                height={GLOBAL.TILE_SIZE / 5}
+                width={GLOBAL.TILE_SIZE}
+            >
+                <ART.Shape
+                    d={p}
+                    stroke="rgba(255, 255, 255, 0.6)"
+                    strokeWidth={1}
+                />
+                <ART.Text
+                    alignment="left"
+                    fill="rgba(255, 255, 255, 0.6)"
+                    font={{
+                        fontFamily: 'Helvetica, Arial',
+                        fontSize: 13,
+                    }}
+                    x={3}
+                    y={0}
+                >
+                    {`${meters}m`}
+                </ART.Text>
+                <ART.Text
+                    alignment="left"
+                    fill="rgba(255, 255, 255, 0.6)"
+                    font={{
+                        fontFamily: 'Helvetica, Arial',
+                        fontSize: 13,
+                    }}
+                    x={3}
+                    y={17}
+                >
+                    {`${feet}ft`}
+                </ART.Text>
+            </ART.Surface>
+        </View>
+    );
+};

--- a/src/shared/common/ScaleBar.js
+++ b/src/shared/common/ScaleBar.js
@@ -12,7 +12,7 @@ type Props = {
     zoomLevel: number,
 };
 
-const getScaleBar = (meters, feet) => {
+const getScaleBar = (meters, feet, tileWidth) => {
     /*
      * produce a shape like
      * |       |
@@ -21,15 +21,18 @@ const getScaleBar = (meters, feet) => {
      */
     const top = 0;
     const mid = 16;
+    // convert meters and feet into "pixels" so that we draw at the correct scale!
+    const metersPx = meters / tileWidth * GLOBAL.TILE_SIZE;
+    const feetPx = feet / tileWidth * GLOBAL.TILE_SIZE;
     const bottom = top + 2 * (mid - top);
     const p = ART.Path().moveTo(0, top);
     p.lineTo(0, bottom);
     p.moveTo(0, mid);
-    p.lineTo(meters, mid);
-    p.lineTo(meters, top);
-    p.moveTo(meters, mid);
-    p.lineTo(feet * 0.3048, mid);
-    p.lineTo(feet * 0.3048, bottom);
+    p.lineTo(metersPx, mid);
+    p.lineTo(metersPx, top);
+    p.moveTo(metersPx, mid);
+    p.lineTo(feetPx * 0.3048, mid);
+    p.lineTo(feetPx * 0.3048, bottom);
     return p;
 };
 
@@ -64,7 +67,7 @@ export default (props: Props) => {
         break;
     }
 
-    const p = getScaleBar(meters, feet);
+    const p = getScaleBar(meters, feet, tileWidth);
     return (
         <View style={{
             height: GLOBAL.TILE_SIZE / 5,

--- a/src/shared/flow-types.js
+++ b/src/shared/flow-types.js
@@ -55,6 +55,7 @@ export type SingleImageryProjectType = {
     progress: number,
     state: number,
     tileServer: TileServerType,
+    zoomLevel: number,
 };
 
 export type ChangeDetectionProjectType = {

--- a/src/shared/views/Mapper/index.js
+++ b/src/shared/views/Mapper/index.js
@@ -23,7 +23,7 @@ import type {
     BuiltAreaGroupType,
     CategoriesType,
     NavigationProp,
-    ProjectType,
+    SingleImageryProjectType,
 } from '../../flow-types';
 import {
     COLOR_DEEP_BLUE,
@@ -200,7 +200,7 @@ class _Mapper extends React.Component<Props, State> {
 
     progress: ?BottomProgress;
 
-    project: ProjectType;
+    project: SingleImageryProjectType;
 
     tilePopup: ?React.ComponentType<void>;
 
@@ -336,6 +336,7 @@ class _Mapper extends React.Component<Props, State> {
                     navigation={navigation}
                     projectId={group.projectId}
                     tutorial={tutorial}
+                    zoomLevel={this.project.zoomLevel}
                 />
             );
         } else {


### PR DESCRIPTION
Scalebar added on built area projects, here's what it looks like on my phone.
![Screenshot_20191017-125010](https://user-images.githubusercontent.com/1745184/67006968-3ee34b00-f0de-11e9-8d15-9dfbca42ffcd.png)

It adjusts to the actual zoom level, and latitude, with preset scalebar sizes stolen from OSM
![Screenshot_20191017-125000](https://user-images.githubusercontent.com/1745184/67007087-8c5fb800-f0de-11e9-84b5-4d205548d4f9.png)
