### PR TITLE
Limit nickname to one line

### DIFF
--- a/src/shared/views/MoreOptions.js
+++ b/src/shared/views/MoreOptions.js
@@ -223,7 +223,7 @@ class _MoreOptions extends React.Component<MOProps> {
                         {' '}
                         {level}
                     </Text>
-                    <Text style={styles.infoRightTitle}>
+                    <Text style={styles.infoRightTitle} numberOfLines={1}>
                         {auth.displayName}
                     </Text>
                     <Text style={styles.infoLeft}>


### PR DESCRIPTION
* and by that prevent that it overlaps with the label
  below about the completed tasks

Fixes #135 