### PR TITLE
#190 Setup support for custom tutorials on first project type

### DIFF
--- a/src/shared/Globals.js
+++ b/src/shared/Globals.js
@@ -5,6 +5,7 @@ import {
     LEGACY_TILES,
     BUILDING_FOOTPRINTS,
     CHANGE_DETECTION,
+    COMPLETENESS_PROJECT,
 } from './constants';
 
 // FIXME: check the old calculation to include status bar and soft menu
@@ -33,5 +34,6 @@ module.exports = {
         LEGACY_TILES,
         BUILDING_FOOTPRINTS,
         CHANGE_DETECTION,
+        COMPLETENESS_PROJECT,
     ],
 };

--- a/src/shared/common/firebaseFunctions.js
+++ b/src/shared/common/firebaseFunctions.js
@@ -49,9 +49,14 @@ export const firebaseConnectGroup = (tutorialName?: string) => (
 );
 
 export const mapStateToPropsForGroups = (tutorialName?: string) => (
+    // This function is a common mapStateToProps used to fetch groups from firebase.
+    // It looks at a few things to decide which group to fetch, based on the project
+    // object that is passed as an argument to the navigation object.
+
     // $FlowFixMe
     (state, ownProps) => {
         let tutorialProjectName;
+        // ownProps are the props passed to the Mapper or ChangeDetection component
         if (tutorialName === undefined) {
             tutorialProjectName = ownProps.tutorialName;
         } else {

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -5,6 +5,7 @@
 export const LEGACY_TILES: number = 1;
 export const BUILDING_FOOTPRINTS: number = 2;
 export const CHANGE_DETECTION: number = 3;
+export const COMPLETENESS_PROJECT: number = 4;
 
 // colours
 export const COLOR_DEEP_BLUE = '#0d1949';

--- a/src/shared/views/Mapper/CardBody.js
+++ b/src/shared/views/Mapper/CardBody.js
@@ -383,7 +383,7 @@ const mapStateToProps = (state, ownProps) => (
         mapper: ownProps.mapper,
         navigation: ownProps.navigation,
         projectId: ownProps.projectId,
-        results: get(state.results.build_area_tutorial, ownProps.group.groupId, null),
+        results: get(state.results[ownProps.tutorialName], ownProps.group.groupId, null),
         tutorial: ownProps.tutorial,
         zoomLevel: ownProps.zoomLevel,
     }

--- a/src/shared/views/Mapper/index.js
+++ b/src/shared/views/Mapper/index.js
@@ -28,6 +28,8 @@ import type {
 } from '../../flow-types';
 import {
     COLOR_DEEP_BLUE,
+    COMPLETENESS_PROJECT,
+    LEGACY_TILES,
 } from '../../constants';
 
 const Modal = require('react-native-modalbox');
@@ -388,15 +390,13 @@ const mapDispatchToProps = (dispatch) => (
     }
 );
 
-const tutorialName = 'build_area_tutorial';
-
 const Mapper = compose(
-    firebaseConnectGroup(tutorialName),
+    firebaseConnectGroup(),
     connect(
         (state) => ({ hasSeenHelpBoxType1: state.ui.user.hasSeenHelpBoxType1 }),
     ),
     connect(
-        mapStateToPropsForGroups(tutorialName),
+        mapStateToPropsForGroups(),
         mapDispatchToProps,
     ),
 )(_Mapper);
@@ -412,9 +412,29 @@ export default class MapperScreen extends React.Component<Props> {
 
     render() {
         const { ...otherProps } = this.props;
+        const projectObj = otherProps.navigation.getParam('project', false);
+        // check if the project data has a custom tutorialName set (in firebase)
+        // in which case, we use it as the tutorial, or fallback onto the default
+        // tutorial content based on the project type
+        let tutorialName;
+        if (projectObj.tutorialName !== undefined) {
+            tutorialName = projectObj.tutorialName;
+        } else {
+            switch (projectObj.projectType) {
+            case LEGACY_TILES:
+                tutorialName = 'build_area_tutorial';
+                break;
+            case COMPLETENESS_PROJECT:
+                tutorialName = 'completeness_tutorial';
+                break;
+            default:
+                console.log('Project type not supported');
+            }
+        }
         return (
             <Mapper
                 randomSeed={this.randomSeed}
+                tutorialName={tutorialName}
                 {...otherProps}
             />
         );

--- a/src/shared/views/Mapper/index.js
+++ b/src/shared/views/Mapper/index.js
@@ -116,6 +116,7 @@ type Props = {
     onStartGroup: {} => void,
     hasSeenHelpBoxType1: boolean,
     tutorial: boolean,
+    tutorialName: string,
 }
 
 type State = {
@@ -327,6 +328,7 @@ class _Mapper extends React.Component<Props, State> {
             group,
             navigation,
             tutorial,
+            tutorialName,
         } = this.props;
         const { poppedUpTile } = this.state;
         let comp;
@@ -340,6 +342,7 @@ class _Mapper extends React.Component<Props, State> {
                     navigation={navigation}
                     projectId={group.projectId}
                     tutorial={tutorial}
+                    tutorialName={tutorialName}
                     zoomLevel={this.project.zoomLevel}
                 />
             );

--- a/src/shared/views/ProjectView.js
+++ b/src/shared/views/ProjectView.js
@@ -26,6 +26,7 @@ import {
     COLOR_DEEP_BLUE,
     COLOR_LIGHT_GRAY,
     COLOR_WHITE,
+    COMPLETENESS_PROJECT,
     LEGACY_TILES,
 } from '../constants';
 import { getProjectProgressForDisplay } from '../Database';
@@ -331,6 +332,7 @@ class _ProjectHeader extends React.Component<HeaderProps, HeaderState> {
             projectType: project.projectType,
         });
         switch (project.projectType) {
+        case COMPLETENESS_PROJECT:
         case LEGACY_TILES:
             // this is the original project type
             navigation.push('Mapper', {
@@ -510,7 +512,8 @@ class _ProjectHeader extends React.Component<HeaderProps, HeaderState> {
                             fb.analytics().logEvent('starting_tutorial', {
                                 projectType: project.projectType,
                             });
-                            if (project.projectType === LEGACY_TILES) {
+                            if ((project.projectType === LEGACY_TILES)
+                                || (project.projectType === COMPLETENESS_PROJECT)) {
                                 navigation.push('Mapper', {
                                     project,
                                     tutorial: true,


### PR DESCRIPTION
This commit also adds support for a "completeness" project type (4).

@TahiraU have a look at the changes in here, some of them might overlap with what you are working on.

The changes here make it possible to select a specific tutorial per project:
- set a `tutorialName` key under the project in firebase with a value set to the tutorial name, such as `build_area_tutorial` to use that specific one
- if no such key exists, the app will select the default tutorial based on the project type