### PR TITLE
Add docs on how to use the test app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,19 +16,11 @@ See [Setting up a development environment for Android](docs/develop-android.md) 
 
 See [Setting up a developer environment for iOS](docs/develop-ios.md).
 
-### Assembling a Release
-
-Note: this section is mostly for reference, as releases are automatically produced by travis CI. You can safely ignore this section for now.
-
-To assemble a release for Android, you'll have to set up your Android development environment to generate a signed APK. The React Native docs have [instructions](https://facebook.github.io/react-native/docs/signed-apk-android.html) on this to follow. To generate a signed release, you'll need to obtain the release keystore file from a MapSwipe developer as well as the credentials for it. Note, generating a signed release is only necessary for updating the app on the Google Play store.
-
-When creating a new release for the Play store, you'll need to increment the `versionCode` and the `versionName` so that they don't clash with existing versions. See [Version numbering](#version-numbering) below on how to do this.
-
 ## Developping and debugging
 
 ## Travis setup
 
-See the [deployment page](docs/deployment).
+See the [deployment page](docs/deployment.md).
 
 ### Deployment to github releases
 
@@ -37,6 +29,10 @@ See https://docs.travis-ci.com/user/deployment/releases/. To pick the right repo
 ```
 travis setup releases --org -r mapswipe/mapswipe
 ```
+
+## Testing the development app
+
+Find out how to install the latest test version of MapSwipe [on this page](docs/test_dev_version.md).
 
 ## Translating the app
 

--- a/docs/test_dev_version.md
+++ b/docs/test_dev_version.md
@@ -1,0 +1,38 @@
+# How to test the development version of MapSwipe
+
+If you want to see the latest developments of the app, or to test a specific new feature, you can install the "development" version of the app.
+
+It can be used side by side with the normal ("production") app, so it won't affect your normal MapSwiping :)
+
+## 1 - Install the app
+
+### Android
+
+From your phone, head to [the MapSwipe releases page](https://github.com/mapswipe/mapswipe/releases) on Github, and select the latest version ending in `-beta` (unless you've been asked to test a specific version). Expand the "Assets" dropdown just under it, and download the `app-dev-release.apk` onto your phone.
+
+Android should automatically ask if you want to install this app. Just say ok, and you're all set.
+
+In some cases, you might need to allow your phone to install apps from "untrusted sources". The details vary, but [this article](https://www.maketecheasier.com/install-apps-from-unknown-sources-android/) should give you a good idea how to do it.
+
+### iOS
+
+If you have an iPhone, you first need to install an app called [TestFlight](https://apps.apple.com/us/app/testflight/id899247664) from the AppStore. It's an official Apple app, so you shouldn't have to worry about it.
+
+Once installed, email us at [info@mapswipe.org](mailto:info@mapswipe.org) to request an invitation link to the test programme. Make sure to include your Apple ID (it's an email address) in your request.
+
+
+## 2 - Run the app
+
+When you open the app, it will look exactly like the "normal" MapSwipe. This one runs on a separate server, so you will need to create an account on it first. You can use the same email/login as the normal app, or anything you want. This account will be completely separate from your "real" one, so your stats will be different, etc...
+
+There is a variable number of projects available on the dev app, and you're welcome to try any of them. Just be aware that things may not be working as expected, or not at all.
+
+Do not think too much about the quality of your work here because it all gets thrown away every now and then!
+
+## 3 - Let us know
+
+Please let us know how things went, as your feedback directly helps us improve the app and make sure bugs don't make it to the wider public.
+
+The best way to report on your findings is on [our issue tracker](https://github.com/mapswipe/mapswipe/issues). If this feels overwhelming, you can also email us at [info@mapswipe.org](mailto:info@mapswipe.org), but we might be slower at responding there.
+
+Happy testing!


### PR DESCRIPTION
I wrote a short doc about how to install and run the test app, so that we can easily point volunteers to it. Can you have a quick read through and let me know if I've missed anything?

The bits I've removed are already on other pages in more details, so this was a bit redundant.