### PR TITLE
Remove timestamp value

### DIFF
--- a/src/shared/actions/index.js
+++ b/src/shared/actions/index.js
@@ -199,15 +199,13 @@ export function commitGroup(groupInfo: GroupInfo): ThunkAction {
         const firebase = getFirebase();
         const userId = firebase.auth().currentUser.uid;
         // get a single timestamp upon completion of the group
-        const timestamp = GLOBAL.DB.getTimestamp();
-        const endTime = timestamp;
+        const endTime = GLOBAL.DB.getTimestamp();
         const { groupId, projectId, results } = groupInfo;
         dispatch(startSendingResults(projectId, groupId));
         const { startTime, ...rest } = results[projectId][groupId];
         const objToUpload = {
             startTime,
             endTime,
-            timestamp,
             results: rest,
         };
         const fbPath = `v2/results/${projectId}/${groupId}/${userId}/`;

--- a/src/shared/actions/index.js
+++ b/src/shared/actions/index.js
@@ -70,20 +70,19 @@ type StartGroup = {
     type: typeof START_GROUP,
     projectId: string,
     groupId: string,
-    timestamp: number,
+    startTime: number,
 };
 export function startGroup(grp: {
     projectId: string,
     groupId: string,
-    timestamp: number,
+    startTime: number,
 }): StartGroup {
-    // dispatched when the user cancels work on a group midway
-    // this forces deletion of the results created so far
+    // dispatched when the user starts work on a group
     return {
         type: START_GROUP,
         projectId: grp.projectId,
         groupId: grp.groupId,
-        timestamp: grp.timestamp,
+        startTime: grp.startTime,
     };
 }
 

--- a/src/shared/common/ProjectLevelScreen.js
+++ b/src/shared/common/ProjectLevelScreen.js
@@ -110,7 +110,7 @@ class ProjectLevelScreen extends React.Component<Props, State> {
                     onStartGroup({
                         groupId: group.groupId,
                         projectId: group.projectId,
-                        timestamp: GLOBAL.DB.getTimestamp(),
+                        startTime: GLOBAL.DB.getTimestamp(),
                     });
                     // eslint-disable-next-line react/no-did-update-set-state
                     this.setState({ groupCompleted: false });

--- a/src/shared/common/ProjectLevelScreen.js
+++ b/src/shared/common/ProjectLevelScreen.js
@@ -151,7 +151,6 @@ class ProjectLevelScreen extends React.Component<Props, State> {
             result,
             groupId: group.groupId,
             projectId: this.project.projectId,
-            timestamp: GLOBAL.DB.getTimestamp(),
         };
         onSubmitResult(resultObject);
     };

--- a/src/shared/reducers/results.js
+++ b/src/shared/reducers/results.js
@@ -55,7 +55,7 @@ export default function results(
         case START_GROUP: {
             // log the timestamp of when the user started mapping
             // there might be results stored already, make sure we keep them
-            const { projectId, groupId, timestamp } = action;
+            const { projectId, groupId, startTime } = action;
             const otherGroups = state[projectId] || {};
             const previousResults = state[projectId]
                 ? state[projectId][groupId]
@@ -66,7 +66,7 @@ export default function results(
                     ...otherGroups,
                     [groupId]: {
                         ...previousResults,
-                        startTime: timestamp,
+                        startTime,
                     },
                 },
             };

--- a/src/shared/views/ChangeDetection/Body.js
+++ b/src/shared/views/ChangeDetection/Body.js
@@ -95,7 +95,7 @@ class _ChangeDetectionBody extends React.Component<Props, State> {
                 onStartGroup({
                     groupId: group.groupId,
                     projectId: group.projectId,
-                    timestamp: GLOBAL.DB.getTimestamp(),
+                    startTime: GLOBAL.DB.getTimestamp(),
                 });
                 if (group.tasks !== undefined) {
                     // eslint-disable-next-line react/no-did-update-set-state

--- a/src/shared/views/ChangeDetection/Body.js
+++ b/src/shared/views/ChangeDetection/Body.js
@@ -137,7 +137,6 @@ class _ChangeDetectionBody extends React.Component<Props, State> {
             result,
             groupId: group.groupId,
             projectId: this.project.projectId,
-            timestamp: GLOBAL.DB.getTimestamp(),
         };
         onSubmitResult(resultObject);
     };

--- a/src/shared/views/Mapper/index.js
+++ b/src/shared/views/Mapper/index.js
@@ -151,7 +151,7 @@ class _Mapper extends React.Component<Props, State> {
             onStartGroup({
                 groupId: group.groupId,
                 projectId: group.projectId,
-                timestamp: GLOBAL.DB.getTimestamp(),
+                startTime: GLOBAL.DB.getTimestamp(),
             });
         }
     }


### PR DESCRIPTION
This PR removes a few `timestamp` variables that were either:
- misnamed, and I renamed them to `startTime` for more clarity
- useless, the value was passed in the action, but never actually stored, not even locally
- not wanted in firebase, this is what #227 is really about
Fixes #227
