### PR TITLE
#236 Update iOS dev env setup docs

### DIFF
--- a/docs/develop-ios.md
+++ b/docs/develop-ios.md
@@ -26,27 +26,32 @@ You should request access to the `dev-mapswipe` firebase instance, on which ther
 
 Next, download the Firebase Google Services files from Firebase > Settings > Add App > Download files.
 
-Copy the iOS file to `ios/cfg/GoogleService-Info.plist`.
+Copy the iOS file to `ios/cfg/GoogleService-Info.dev.plist` and duplicate it to `ios/cfg/GoogleService-Info.prd.plist` (The build will fail if you don't, even though this seems useless).
+
+You will also get a copy of `sentry.properties` which you will need to copy to `ios/cfg/`.
 
 ### Running the app and developing
 
-Install steps
+#### On the simulator
+
+Install steps:
 
 1. Clone the repo. You will need to setup an SSH key if you want to push any code changes back to github.
 2. Run `yarn install` -> Install the React native dependencies
-3. Run `yarn start` -> Start React Native
+3. Run `yarn start` -> Start React Native. You need to leave this running during your entire development session.
 4. Run `sudo gem install bundler`
 5. Run `bundle install` to install fastlane and cocoapods
 6. Run `cd ios && bundle exec pod install` -> Install (mostly copy) the dependencies for iOS
-7. Login in Xcode as mapswipe.dev@gmail.com. Why ? This allows to share the signing certificates between developers with fastlane match.
-8. Get Access to the gitlab repo with the certificates
-9. Run `fastlane ios matchDev` -> Get the certificates from GitLab repo and add them to your keychain. A password is needed to decrypt the certificates.
-10. Build & run the target mapswipe in debug.
-11. Check that the tests are passing locally: Run `fastlane ios test`
+7. Build & run the target mapswipe in debug.
+8. Check that the tests are passing locally: Run `fastlane ios test`
 
 If you get errors while installing pods (glog specifically), you might want to try this: https://github.com/facebook/react-native/issues/18408#issuecomment-386696744
 
 Note: if you run into weird problems when running `yarn install` and such, and find no logical explanation, you may need to check your version of node (`node -v`). There has been a number of problems with some versions of `react-native` not working on specific versions of node. Overall, it seems that using the LTS version of node works better than the very latest builds.
+
+#### On your phone
+
+You will also need to create a provisioning profile. This [page](https://help.apple.com/xcode/mac/current/#/dev60b6fbbc7) should help.
 
 ### Testing
 

--- a/docs/develop-ios.md
+++ b/docs/develop-ios.md
@@ -22,11 +22,11 @@ Once you have dependencies installed, clone the mapswipe repository.
 
 MapSwipe uses Firebase to handle data transfers. The project won't run unless you create your own Firebase configuration.
 
-You should request access to the `dev-mapswipe` firebase instance, on which there are real test projects to test against. Contact one of the project admins for this (see https://www.mapswipe.org/ for contacts).
+You should request access to the `dev-mapswipe` firebase instance, on which there are real test projects to test against. You can [email us](mailto:info@mapswipe.org) for this.
 
-Next, download the Firebase Google Services files from Firebase > Settings > Add App > Download files.
+We will email you 2 files.
 
-Copy the iOS file to `ios/cfg/GoogleService-Info.dev.plist` and duplicate it to `ios/cfg/GoogleService-Info.prd.plist` (The build will fail if you don't, even though this seems useless).
+Copy `GoogleService-Info.plist` to `ios/cfg/GoogleService-Info.dev.plist` and duplicate it to `ios/cfg/GoogleService-Info.prd.plist` (The build will fail if you don't, even though this seems useless).
 
 You will also get a copy of `sentry.properties` which you will need to copy to `ios/cfg/`.
 
@@ -46,6 +46,8 @@ Install steps:
 8. Check that the tests are passing locally: Run `fastlane ios test`
 
 If you get errors while installing pods (glog specifically), you might want to try this: https://github.com/facebook/react-native/issues/18408#issuecomment-386696744
+
+Another error you might face is "resource fork, Finder information, or similar detritus not allowed", you can fix it by running `xattr -cr .`, see [this page](https://developer.apple.com/library/archive/qa/qa1940/_index.html) for more details.
 
 Note: if you run into weird problems when running `yarn install` and such, and find no logical explanation, you may need to check your version of node (`node -v`). There has been a number of problems with some versions of `react-native` not working on specific versions of node. Overall, it seems that using the LTS version of node works better than the very latest builds.
 


### PR DESCRIPTION
Fixes #236 
This updates the docs for iOS dev env setup, hopefully more in line with what is actually needed. I've removed the parts related to deployment as they are not needed to get started.

@oiva happy to get your feedback on this :)