### PR TITLE
Live updates for project list

### DIFF
--- a/src/shared/views/RecommendedCards.js
+++ b/src/shared/views/RecommendedCards.js
@@ -6,6 +6,7 @@ import { firebaseConnect, isLoaded, isEmpty } from 'react-redux-firebase';
 import { ScrollView, StyleSheet, Text } from 'react-native';
 import Button from 'apsl-react-native-button';
 import Modal from 'react-native-modalbox';
+import type { NavigationEventSubscription } from 'react-navigation';
 import ProjectCard from './ProjectCard';
 import LoadingIcon from './LoadingIcon';
 import type { NavigationProp, ProjectType } from '../flow-types';
@@ -77,12 +78,91 @@ type OrderedProject = {
 
 type Props = {
     announcement: Object,
+    firebase: Object,
     navigation: NavigationProp,
     projects: Array<OrderedProject>,
 };
 
+// request only active projects from firebase (status === 'active')
+// firebase doesn't allow multiple query params, so for project types we filter in render()
+// but here we can still limit to 20 projects maximum
+// `path` defines where the resulting data is copied in the redux store
+// (state.firebase.ordered.projects in this case, because we've asked for `orderByChild`)
+const projectsQuery = {
+    isQuery: true,
+    path: 'v2/projects',
+    queryId: 'projectsQuery',
+    queryParams: ['orderByChild=status', 'equalTo=active', 'limitToFirst=20'],
+    storeAs: 'projects',
+    type: 'value',
+};
+// load any announcement data from firebase
+// (state.firebase.data.announcement here because we've not ordered the query)
+const announcementQuery = {
+    isQuery: true,
+    path: 'v2/announcement',
+    queryId: 'announcementQuery',
+    queryParams: ['limitToLast=2'],
+    storeAs: 'announcement',
+    type: 'value',
+};
+
 class _RecommendedCards extends React.Component<Props> {
     tutorialModal: ?Modal;
+
+    willBlurAnnouncementSubscription: NavigationEventSubscription;
+
+    willFocusAnnouncementSubscription: NavigationEventSubscription;
+
+    willBlurProjectSubscription: NavigationEventSubscription;
+
+    willFocusProjectSubscription: NavigationEventSubscription;
+
+    componentDidMount() {
+        this.subscribeToProjects();
+        this.subscribeToAnnouncements();
+    }
+
+    componentWillUnmount() {
+        this.willFocusAnnouncementSubscription.remove();
+        this.willBlurAnnouncementSubscription.remove();
+        this.willFocusProjectSubscription.remove();
+        this.willBlurProjectSubscription.remove();
+    }
+
+    subscribeToAnnouncements = () => {
+        const { type, path, storeAs, ...options } = announcementQuery;
+        const { firebase, navigation } = this.props;
+        this.willFocusAnnouncementSubscription = navigation.addListener(
+            'willFocus',
+            () => {
+                firebase.watchEvent(type, path, storeAs, options);
+            },
+        );
+        this.willBlurAnnouncementSubscription = navigation.addListener(
+            'willBlur',
+            () => {
+                firebase.unWatchEvent(type, path, storeAs, options);
+            },
+        );
+    };
+
+    subscribeToProjects = () => {
+        const { type, path, storeAs, ...options } = projectsQuery;
+        const { firebase, navigation } = this.props;
+        this.willFocusProjectSubscription = navigation.addListener(
+            'willFocus',
+            () => {
+                firebase.watchEvent(type, path, storeAs, options);
+            },
+        );
+        this.willBlurProjectSubscription = navigation.addListener(
+            'willBlur',
+            () => {
+                firebase.unWatchEvent(type, path, storeAs, options);
+            },
+        );
+    };
 
     closeModal3 = () => {
         if (this.tutorialModal) {
@@ -222,26 +302,11 @@ const mapStateToProps = (state, ownProps) => ({
 });
 
 export default compose(
-    firebaseConnect(() => [
-        // request only active projects from firebase (status === 'active')
-        // firebase doesn't allow multiple query params, so for project types we filter in render()
-        // but here we can still limit to 20 projects maximum
-        // `path` defines where the resulting data is copied in the redux store
-        // (state.firebase.ordered.projects in this case, because we've asked for `orderByChild`)
-        {
-            type: 'once',
-            path: 'v2/projects',
-            queryParams: [
-                'orderByChild=status',
-                'equalTo=active',
-                'limitToFirst=20',
-            ],
-            storeAs: 'projects',
-        },
-        // load any announcement data from firebase
-        // (state.firebase.data.announcement here because we've not ordered the query)
-        { path: 'v2/announcement', queryParams: ['limitToLast=2'] },
-    ]),
+    // this only supplies the firebase object in the props, the actual connection
+    // to projects and announcement is done in componentDidMount
+    // so that we can disable updates while mapping to prevent updates from other
+    // users from resetting our mapping state, see #119
+    firebaseConnect(), //() => [
     // connect to redux store
     connect(mapStateToProps),
 )(_RecommendedCards);


### PR DESCRIPTION
This PR brings back live updates for the project list. We used to see progress and number of mappers increase while on the list of project, but had to disable this to fix #93. Not anymore!

Fixes #119 