### PR TITLE
Add BUNDLE_DISPLAY_NAME for production release

### DIFF
--- a/ios/mapswipe.xcodeproj/project.pbxproj
+++ b/ios/mapswipe.xcodeproj/project.pbxproj
@@ -852,6 +852,7 @@
 			baseConfigurationReference = 1E0592B88B5096FD530933DC /* Pods-mapswipe.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BUNDLE_DISPLAY_NAME = "MapSwipe";
 				CODE_SIGN_ENTITLEMENTS = mapswipe/mapswipe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;


### PR DESCRIPTION
Change the app's name to "MapSwipe" #196

ios/mapswipe/Info.plist seems to use $(BUNDLE_DISPLAY_NAME) variable as
_CFBundleDisplayName_ which is the name shown on users' home screen as the
app name.

The beta version bundle display name is defined in project.pbxproj
(BUNDLE_DISPLAY_NAME = "MapSwipe-beta";) but the release version did not
have BUNDLE_DISPLAY_NAME defined.

Not 100% sure if this will change the app name on iOS as I don't think I can produce production builds to test it. I did test adding the same variable for debug build and it changed the debug app's name in simulator.