### PR TITLE
#264 Add support for private projects

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -46,6 +46,7 @@
     "Level X": "Level {{level}}",
     "youve completed x tasks": "You've completed {{contributions}} tasks!",
     "x tasks (s swipes) until the next level": "{{sqkm}} tasks ({{swipes}} swipes) until the next level",
+    "yourTeam": "Your team: {{teamName}}",
     "changeLanguage": "Change Language",
     "mapswipe website": "MapSwipe website",
     "missingmaps website": "Missing Maps website",

--- a/src/shared/Main.js
+++ b/src/shared/Main.js
@@ -165,7 +165,9 @@ class Main extends React.Component<Props, State> {
     // eslint-disable-next-line class-methods-use-this
     async getNotificationToken() {
         const fcmToken = await fb.messaging().getToken();
-        console.log('FCM token', fcmToken);
+        if (__DEV__) {
+            console.log('FCM token', fcmToken);
+        }
     }
 
     async requestNotificationsPermission() {

--- a/src/shared/flow-types.js
+++ b/src/shared/flow-types.js
@@ -54,7 +54,7 @@ export type SingleImageryProjectType = {
     // FIXME: we should use constants here, somehow flow is not happy with them
     projectType: 1 | 2 | 4,
     progress: number,
-    state: number,
+    status: string,
     tileServer: TileServerType,
     tileServerB: ?TileServerType,
     zoomLevel: number,
@@ -72,7 +72,7 @@ export type ChangeDetectionProjectType = {
     projectId: string,
     projectType: 3,
     progress: number,
-    state: number,
+    status: string,
     tileServerA: TileServerType,
     tileServerB: TileServerType,
 };

--- a/src/shared/reducers/ui.js
+++ b/src/shared/reducers/ui.js
@@ -117,11 +117,14 @@ export default function user(
                 taskContributionCount,
                 level,
             );
+            // $FlowFixMe
+            const teamId = action.profile ? action.profile.teamId : undefined;
             return {
                 ...state,
                 kmTillNextLevel,
                 level,
                 progress: percentage,
+                teamId,
             };
         }
         default:

--- a/src/shared/views/MoreOptions.js
+++ b/src/shared/views/MoreOptions.js
@@ -371,9 +371,7 @@ const mapStateToProps = (state, ownProps) => ({
     profile: state.firebase.profile,
     progress: state.ui.user.progress,
     teamId: state.ui.user.teamId,
-    teamName: state.firebase.data.teamDetails
-        ? state.firebase.data.teamDetails.teamName
-        : undefined,
+    teamName: state.firebase.data.teamName,
 });
 
 const enhance = compose(

--- a/src/shared/views/MoreOptions.js
+++ b/src/shared/views/MoreOptions.js
@@ -135,6 +135,8 @@ type MOProps = {
     profile: Object,
     progress: number,
     t: TranslationFunction,
+    teamId: ?string,
+    teamName: ?string,
 };
 
 // eslint-disable-next-line react/prefer-stateless-function
@@ -225,6 +227,8 @@ class _MoreOptions extends React.Component<MOProps> {
             profile,
             progress,
             t,
+            teamId,
+            teamName,
         } = this.props;
         const levelObject = Levels[level];
         const contributions =
@@ -265,6 +269,18 @@ class _MoreOptions extends React.Component<MOProps> {
                     progress={progress}
                     t={t}
                 />
+                {teamId && (
+                    <View style={styles.row}>
+                        <Text
+                            style={[
+                                styles.buttonText,
+                                { height: 30, marginTop: 10 },
+                            ]}
+                        >
+                            {t('yourTeam', { teamName })}
+                        </Text>
+                    </View>
+                )}
                 <View style={styles.row}>
                     <Button
                         onPress={() => {
@@ -354,6 +370,10 @@ const mapStateToProps = (state, ownProps) => ({
     navigation: ownProps.navigation,
     profile: state.firebase.profile,
     progress: state.ui.user.progress,
+    teamId: state.ui.user.teamId,
+    teamName: state.firebase.data.teamDetails
+        ? state.firebase.data.teamDetails.teamName
+        : undefined,
 });
 
 const enhance = compose(

--- a/src/shared/views/RecommendedCards.js
+++ b/src/shared/views/RecommendedCards.js
@@ -180,10 +180,14 @@ class _RecommendedCards extends React.Component<Props> {
 
     getTeamName = () => {
         // request the team display name from firebase
-        // the result is then available under state.firebase.data.teamDetails
+        // the result is then available under state.firebase.data.teamName
         const { firebase, teamId } = this.props;
         if (teamId) {
-            firebase.watchEvent('once', `v2/teams/${teamId}`, 'teamDetails');
+            firebase.watchEvent(
+                'once',
+                `v2/teams/${teamId}/teamName`,
+                'teamName',
+            );
         }
     };
 


### PR DESCRIPTION
This PR fixes #264 by adding basic support for private projects.

If the user is part of a team, the app simply pulls private projects assigned to their team. The user can confirm if they're part of a team by checking their profile page, which shows the team name if relevant, nothing otherwise.