### PR TITLE
#377 Support basic http auth in imagery urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.9.0",
     "babel-plugin-transform-remove-console": "^6.9.4",
+    "base-64": "^0.1.0",
     "detox": "^13.0.2",
     "eslint": "^6.5.1",
     "eslint-config-airbnb": "^18.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2603,6 +2603,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base-64@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+  integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
+
 base64-js@^1.1.2, base64-js@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"


### PR DESCRIPTION
This PR adds support for basic http auth in imagery urls.

When creating a project, nothing changes for regular imagery sources, but if a basic auth scheme is used, the url for the imagery must be entered in the form using the standard format: `http://username:password@url` (or https if required). There is no need to use base64 or any other encoding.

React native's http client does not handle this scheme by default, instead if requires passing a `Authorization: Basic username:password` header where `username:password` is base64 encoded.
I've updated the code that grabs the url for imagery to detect if the url follows this scheme (using a regular expression) and splits the url as needed to provide the required headers. The previous logic still applies to normal urls.