### PR TITLE
#374 Fix crash on start due to xx language code

### DIFF
--- a/src/shared/common/LanguageSelectionSplashScreen.js
+++ b/src/shared/common/LanguageSelectionSplashScreen.js
@@ -94,10 +94,12 @@ type Props = {
 class _LanguageSelectionSplashScreen extends React.Component<Props> {
     componentDidMount() {
         const { languageCode, navigation } = this.props;
-        if (languageCode !== 'xx') {
-            navigation.navigate('WelcomeScreen');
-        } else {
+        if (languageCode === undefined || languageCode === 'xx') {
+            // no language selected, show this screen
             SplashScreen.hide();
+        } else {
+            // the user has already picked a language, move on to the next screen
+            navigation.navigate('WelcomeScreen');
         }
     }
 
@@ -118,7 +120,11 @@ class _LanguageSelectionSplashScreen extends React.Component<Props> {
         const { languageCode, t } = this.props;
 
         // if the language code is unset, default to english for the first display
-        const actualLangCode = languageCode === 'xx' ? 'en' : languageCode;
+        // we also allow for xx as a legacy code from 2.0.5 (which should not have happened)
+        const actualLangCode =
+            languageCode === undefined || languageCode === 'xx'
+                ? 'en'
+                : languageCode;
         const languageName = supportedLanguages.filter(
             (item) => item.code === actualLangCode,
         )[0].name;

--- a/src/shared/reducers/ui.js
+++ b/src/shared/reducers/ui.js
@@ -17,7 +17,7 @@ const defaultUserState = {
     // This allows showing the help text when the user first opens a project of that type
     hasSeenHelpBoxType1: false,
     kmTillNextLevel: 0,
-    languageCode: 'xx',
+    languageCode: undefined,
     level: 1,
     progress: 0,
     username: '',


### PR DESCRIPTION
This PR attempts to fix the crash observed upon app start with `2.0.5(0)`, which appears to be caused by the `xx` language code that was the default value expected from redux. When upgrading from the previous version, it looks like the language code was set instead to `undefined`, which was not handled in the current code, leading to the crash.
This patch should fix this, and also handle the case where the code happens to be `xx`. This should not happen, but we might as well err on the side of safety at this point!

Sorry @Hagellach37 for not seeing the problem you had pointed out in your review of the PR for `2.0.5`!