### PR TITLE
Prepare for release 2.0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ matrix:
         components:
           - tools
           - platform-tools
-          - build-tools-28.0.3
-          - android-28
+          - build-tools-29.0.3
+          - android-29
           - extra-android-m2repository
           - extra-google-google_play_services
           - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
         - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.17.3
         - export PATH="$HOME/.yarn/bin:$PATH"
         - gem install bundler
+        # force manual license acceptance when switching to build-tools 29
+        - yes | sdkmanager "platforms;android-28"
       install:
         - yarn install --frozen-lockfile
         - touch $HOME/.android/repositories.cfg
@@ -42,7 +44,9 @@ matrix:
         components:
           - tools
           - platform-tools
+          - build-tools-28.0.3
           - build-tools-29.0.3
+          - android-28
           - android-29
           - extra-android-m2repository
           - extra-google-google_play_services

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "28.0.3"
+        buildToolsVersion = "29.0.3"
         minSdkVersion = 18 // this should be 16 if we're not running the detox test build
-        compileSdkVersion = 28
-        targetSdkVersion = 28
+        compileSdkVersion = 29
+        targetSdkVersion = 29
         androidXCore = "1.0.2"
         kotlinVersion = '1.3.10'
     }

--- a/ios/mapswipe-tvOS/Info.plist
+++ b/ios/mapswipe-tvOS/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.8</string>
+	<string>2.0.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/ios/mapswipe-tvOSTests/Info.plist
+++ b/ios/mapswipe-tvOSTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.8</string>
+	<string>2.0.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>0</string>
 </dict>
 </plist>

--- a/ios/mapswipe.xcodeproj/project.pbxproj
+++ b/ios/mapswipe.xcodeproj/project.pbxproj
@@ -825,7 +825,7 @@
 				CODE_SIGN_ENTITLEMENTS = mapswipe/mapswipe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 0;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = N4W28E5PA4;
 				HEADER_SEARCH_PATHS = (
@@ -856,7 +856,7 @@
 				CODE_SIGN_ENTITLEMENTS = mapswipe/mapswipe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = N4W28E5PA4;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1233,7 +1233,7 @@
 				CODE_SIGN_ENTITLEMENTS = mapswipe/mapswipe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = N4W28E5PA4;
 				FIREBASE_CONFIG_EXTENSION = dev;
 				HEADER_SEARCH_PATHS = (

--- a/ios/mapswipe/Info.plist
+++ b/ios/mapswipe/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.8</string>
+	<string>2.0.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/mapswipeTests/Info.plist
+++ b/ios/mapswipeTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.8</string>
+	<string>2.0.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>0</string>
 </dict>
 </plist>

--- a/ios/mapswipeUITests/Info.plist
+++ b/ios/mapswipeUITests/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.8</string>
+	<string>2.0.9</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>0</string>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-native-simple-markdown": "mapswipe/react-native-simple-markdown#master",
     "react-native-splash-screen": "^3.1.1",
     "react-native-swiper": "1.6.0-rc.3",
-    "react-native-webview": "^7.6.0",
+    "react-native-webview": "^11.0.0",
     "react-navigation": "^4.3.3",
     "react-navigation-stack": "^2.3.7",
     "react-redux": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapswipe",
-  "version": "2.0.8",
-  "build": "9",
+  "version": "2.0.9",
+  "build": "0",
   "private": true,
   "scripts": {
     "buildDev": "cd android && ./gradlew assembleDevRelease && cd ..",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7828,10 +7828,10 @@ react-native-swiper@1.6.0-rc.3:
   dependencies:
     prop-types "^15.5.10"
 
-react-native-webview@^7.6.0:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-7.6.0.tgz#6bae76430200be5e5ead7d986af2fa341b650186"
-  integrity sha512-IQWtIpCTYb4dTshAJO3hMM9Ms5T6KRpk6qWqgBTGMdmgeEvSxWz9l7Og1ALhb7T7NoAnPy8w/dQmD9LlbGGs5g==
+react-native-webview@^11.0.0:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.0.2.tgz#c88e84fa470f04ff070ff8a2c7f4d7295d46bb06"
+  integrity sha512-GDyIBRbCZ2wbMUGCxA7LufSEbSoWKOzkFB8YljmAffA15tzN6ccvGEquB/hkk5KhvoYy300kwJyEmyBeG6d/AA==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
We are skipping 2.0.9 as there was a build/release problem with android (due to google's requirement to upgrade target sdk version to 29). Plus 2.0.9 was tagged on the wrong branch (mea culpa).