### PR TITLE
display imagery correctly and avoid overlay in change detection projects

### DIFF
--- a/src/shared/common/SatImage.js
+++ b/src/shared/common/SatImage.js
@@ -105,6 +105,7 @@ export default class SatImage extends React.Component<Props, State> {
                         results={0}
                         style={styles.imageBackground}
                         tile={task}
+                        source={source}
                         tutorial={false}
                     />
                 ) : (

--- a/src/shared/views/ChangeDetection/Tile.js
+++ b/src/shared/views/ChangeDetection/Tile.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { firebaseConnect } from 'react-redux-firebase';
 import {
     ImageBackground,
+    Image,
     View,
     StyleSheet,
     TouchableHighlight,
@@ -52,6 +53,7 @@ type Props = {
     onToggleTile: (ResultType) => void,
     results: number,
     style: ViewStyleProp,
+    source: Image.ImageSourcePropType,
     tutorial: boolean,
 };
 

--- a/src/shared/views/ChangeDetection/Tile.js
+++ b/src/shared/views/ChangeDetection/Tile.js
@@ -44,11 +44,6 @@ const styles = StyleSheet.create({
         opacity: 0.3,
         aspectRatio: 1,
     },
-    buildingStyle: {
-        borderWidth: 0.5,
-        borderColor: 'rgba(255, 255, 255, 0.2)',
-        opacity: 0.7,
-    },
 });
 
 type Props = {
@@ -141,7 +136,6 @@ export class _Tile extends React.PureComponent<Props> {
         return { uri: source.uri };
     };
 
-
     zoomRender = () => {
         const imageSource = this.getImgSource();
         return (
@@ -154,8 +148,7 @@ export class _Tile extends React.PureComponent<Props> {
                         borderColor: 'rgba(255,255,255,0.2)',
                     }}
                     source={imageSource}
-                >
-                </ImageBackground>
+                />
             </TouchableHighlight>
         );
     };
@@ -184,14 +177,9 @@ export class _Tile extends React.PureComponent<Props> {
             );
         }
         const imageSource = this.getImgSource();
-        let comp;
-
-        comp = (
+        const comp = (
             <View
-                style={[
-                    styles.tileOverlay,
-                    { backgroundColor: overlayColor },
-                ]}
+                style={[styles.tileOverlay, { backgroundColor: overlayColor }]}
                 key={`view-${taskId}`}
             >
                 {animatedRows}

--- a/src/shared/views/ChangeDetection/Tile.js
+++ b/src/shared/views/ChangeDetection/Tile.js
@@ -137,18 +137,13 @@ export class _Tile extends React.PureComponent<Props> {
     };
 
     getImgSource = () => {
-        const { tile } = this.props;
-        return { uri: tile.url };
+        const { source } = this.props;
+        return { uri: source.uri };
     };
 
-    getOsmBuildingsUrl = () => {
-        const { tile } = this.props;
-        return { uri: tile.urlB };
-    };
 
     zoomRender = () => {
         const imageSource = this.getImgSource();
-        const osmBuildingsImageSource = this.getOsmBuildingsUrl();
         return (
             <TouchableHighlight onPress={this.onDismissZoom}>
                 <ImageBackground
@@ -160,16 +155,6 @@ export class _Tile extends React.PureComponent<Props> {
                     }}
                     source={imageSource}
                 >
-                    <ImageBackground
-                        style={{
-                            height: 300,
-                            width: 300,
-                            borderWidth: 0.5,
-                            borderColor: 'rgba(255,255,255,0.2)',
-                            opacity: 0.7,
-                        }}
-                        source={osmBuildingsImageSource}
-                    />
                 </ImageBackground>
             </TouchableHighlight>
         );
@@ -201,36 +186,17 @@ export class _Tile extends React.PureComponent<Props> {
         const imageSource = this.getImgSource();
         let comp;
 
-        if (this.getOsmBuildingsUrl() !== undefined) {
-            comp = (
-                <ImageBackground
-                    style={styles.buildingStyle}
-                    source={this.getOsmBuildingsUrl()}
-                >
-                    <View
-                        style={[
-                            styles.tileOverlay,
-                            { backgroundColor: overlayColor },
-                        ]}
-                        key={`view-${taskId}`}
-                    >
-                        {animatedRows}
-                    </View>
-                </ImageBackground>
-            );
-        } else {
-            comp = (
-                <View
-                    style={[
-                        styles.tileOverlay,
-                        { backgroundColor: overlayColor },
-                    ]}
-                    key={`view-${taskId}`}
-                >
-                    {animatedRows}
-                </View>
-            );
-        }
+        comp = (
+            <View
+                style={[
+                    styles.tileOverlay,
+                    { backgroundColor: overlayColor },
+                ]}
+                key={`view-${taskId}`}
+            >
+                {animatedRows}
+            </View>
+        );
 
         return (
             <TouchableHighlight

--- a/src/shared/views/ChangeDetection/Tile.js
+++ b/src/shared/views/ChangeDetection/Tile.js
@@ -179,14 +179,6 @@ export class _Tile extends React.PureComponent<Props> {
             );
         }
         const imageSource = this.getImgSource();
-        const comp = (
-            <View
-                style={[styles.tileOverlay, { backgroundColor: overlayColor }]}
-                key={`view-${taskId}`}
-            >
-                {animatedRows}
-            </View>
-        );
 
         return (
             <TouchableHighlight
@@ -200,7 +192,15 @@ export class _Tile extends React.PureComponent<Props> {
                     key={`touch-${taskId}`}
                     source={imageSource}
                 >
-                    {comp}
+                    <View
+                        style={[
+                            styles.tileOverlay,
+                            { backgroundColor: overlayColor },
+                        ]}
+                        key={`view-${taskId}`}
+                    >
+                        {animatedRows}
+                    </View>
                 </ImageBackground>
             </TouchableHighlight>
         );


### PR DESCRIPTION
This is just a tiny change to how the images are loaded for the change detection project type. (second try)

closes #492 