### PR TITLE
Fix crash when swiping between tabs on ios

### DIFF
--- a/src/shared/common/ScrollableTabView/ScrollableTabView.js
+++ b/src/shared/common/ScrollableTabView/ScrollableTabView.js
@@ -232,13 +232,13 @@ class ScrollableTabView extends React.Component<Props, State> {
         });
     }
 
-    _onMomentumScrollBeginAndEnd(e) {
+    _onMomentumScrollBeginAndEnd = e => {
         const offsetX = e.nativeEvent.contentOffset.x;
         const page = Math.round(offsetX / this.state.containerWidth);
         if (this.state.currentPage !== page) {
             this._updateSelectedPage(page);
         }
-    }
+    };
 
     _updateSelectedPage = nextPage => {
         let localNextPage = nextPage;


### PR DESCRIPTION
The crash was due to `this` not being bound in the class method, this syntax change solves this.
The bug only happens on iOS because the code paths are quite different between platforms.