### PR TITLE
Add pre-release PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_release.md
@@ -13,7 +13,7 @@ If this is not what you are doing, you can skip this template.
 - [ ] Any commit to `master` since the last release are also merged into `dev`.
 - [ ] The code is commented enough to be understandable by another developer (someone has reviewed my code)
 - [ ] Reference related issues in the PR description
-- [ [ Check that all translations are included in `src/shared/18n.js` and `src/shared/constant.js`
+- [ ] Check that all translations are included in `src/shared/18n.js` and `src/shared/constant.js`
 - [ ] All translation PRs are merged into `dev`.
 - [ ] Check all security alerts and either close or merge them
 - [ ] Verify outdated dependencies (with `yarn outdated`) and upgrade them

--- a/.github/PULL_REQUEST_TEMPLATE/new_release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_release.md
@@ -1,0 +1,29 @@
+---
+name: Prepare a release
+about: A PR that prepares for a new production release
+---
+
+**Release checklist**
+
+This template only applies to a PR that prepares a new release (ie. a PR from `dev` into `master`).
+If this is not what you are doing, you can skip this template.
+
+- [ ] The CI checks are passing before merging the PR
+- [ ] I've rebased my branch off a recent `dev` branch commit, or merged `dev` into my branch and resolved all conflicts
+- [ ] Any commit to `master` since the last release are also merged into `dev`.
+- [ ] The code is commented enough to be understandable by another developer (someone has reviewed my code)
+- [ ] Reference related issues in the PR description
+- [ [ Check that all translations are included in `src/shared/18n.js` and `src/shared/constant.js`
+- [ ] All translation PRs are merged into `dev`.
+- [ ] Check all security alerts and either close or merge them
+- [ ] Verify outdated dependencies (with `yarn outdated`) and upgrade them
+- [ ] Update [fastlane and cocoapods](docs/upgrading_dependencies.md)
+- [ ] Check CI logs for the previous release (particularly around the playstore/appstore uploads from fastlane) for
+  warnings about upcoming requirements
+- [ ] The next [milestone](https://github.com/mapswipe/mapswipe/milestones) is created
+- [ ] All items in the current release milestone are closed or reassigned to the next milestone
+- [ ] PRs that are not needed are closed
+
+**Draft release notes**
+
+Please write release notes here. Bullet points are fine.

--- a/.github/PULL_REQUEST_TEMPLATE/new_release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_release.md
@@ -3,27 +3,34 @@ name: Prepare a release
 about: A PR that prepares for a new production release
 ---
 
-**Release checklist**
+## Release checklist
 
-This template only applies to a PR that prepares a new release (ie. a PR from `dev` into `master`).
+This template only applies to a PR that prepares a new production release (ie. a PR from `dev` into `master`).
 If this is not what you are doing, you can skip this template.
 
+### General
+- [ ] The code is commented enough to be understandable by another developer
+- [ ] someone has reviewed my code
 - [ ] The CI checks are passing before merging the PR
 - [ ] I've rebased my branch off a recent `dev` branch commit, or merged `dev` into my branch and resolved all conflicts
 - [ ] Any commit to `master` since the last release are also merged into `dev`.
-- [ ] The code is commented enough to be understandable by another developer (someone has reviewed my code)
 - [ ] Reference related issues in the PR description
+- [ ] The next [milestone](https://github.com/mapswipe/mapswipe/milestones) is created
+- [ ] All items in the current release milestone are closed or reassigned to the next milestone
+- [ ] PRs that are not needed are closed
+
+### Translation
 - [ ] Check that all translations are included in `src/shared/18n.js` and `src/shared/constant.js`
 - [ ] All translation PRs are merged into `dev`.
+
+### Dependencies and Security Alerts
 - [ ] Check all security alerts and either close or merge them
 - [ ] Verify outdated dependencies (with `yarn outdated`) and upgrade them
 - [ ] Update [fastlane and cocoapods](docs/upgrading_dependencies.md)
 - [ ] Check CI logs for the previous release (particularly around the playstore/appstore uploads from fastlane) for
   warnings about upcoming requirements
-- [ ] The next [milestone](https://github.com/mapswipe/mapswipe/milestones) is created
-- [ ] All items in the current release milestone are closed or reassigned to the next milestone
-- [ ] PRs that are not needed are closed
 
-**Draft release notes**
+
+## Draft release notes
 
 Please write release notes here. Bullet points are fine.


### PR DESCRIPTION
Closes #546 

This PR adds a template for PRs that prepare a production release, with a checklist meant to avoid forgetting the basics.

Feel free to add links to documentation or less code-related items.