### PR TITLE
Try to renew apple certificates for 2023

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -98,6 +98,21 @@ jobs:
           SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
         run: echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
 
+      - name: TEMP renew dev certificates
+        env:
+          FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+          FASTLANE_SESSION: ${{ secrets.FASTLANE_SESSION }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        run: cd ios && bundle exec fastlane env && bundle exec fastlane ios matchDev
+
+      - name: TEMP renew prod certificates
+        env:
+          FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+          FASTLANE_SESSION: ${{ secrets.FASTLANE_SESSION }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        run: cd ios && bundle exec fastlane ios matchProd
+
+
       - name: Build the app and run unit tests
         # The test lane refreshes the development certificates, compiles the app and launches the unit tests.
         # Actual Tests have been disabled since we had issues launching the simulator, but the app is being compiled.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -11,11 +11,11 @@ platform :ios do
 
   desc "Update dev certificates locally"
   lane :matchDev do
-      match(type: "development", app_identifier: "org.missingmaps.mapswipe-dev", readonly: is_ci)
+      match(type: "development", app_identifier: "org.missingmaps.mapswipe-dev", readonly: false, verbose: true, git_private_key: "/Users/runner/work/mapswipe/mapswipe/ios/cfg/mapswipe.dev_at_gmail_rsa_key_for_travis_ci")
   end
 
   lane :matchProd do
-    match(type: "appstore", app_identifier: "org.missingmaps.mapswipe", readonly: is_ci)
+    match(type: "appstore", app_identifier: "org.missingmaps.mapswipe", readonly: false, verbose: true, git_private_key: "/Users/runner/work/mapswipe/mapswipe/ios/cfg/mapswipe.dev_at_gmail_rsa_key_for_travis_ci")
   end
 
   desc "Build the app and run the tests defined for the mapswipe scheme. Used in github actions to trigger the CI step."

--- a/ios/mapswipe.xcodeproj/project.pbxproj
+++ b/ios/mapswipe.xcodeproj/project.pbxproj
@@ -665,7 +665,7 @@
 				CODE_SIGN_ENTITLEMENTS = mapswipe/mapswipe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N4W28E5PA4;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -702,7 +702,7 @@
 				CODE_SIGN_ENTITLEMENTS = mapswipe/mapswipe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N4W28E5PA4;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1025,7 +1025,7 @@
 				CODE_SIGN_ENTITLEMENTS = mapswipe/mapswipe.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N4W28E5PA4;
 				ENABLE_BITCODE = NO;
 				FIREBASE_CONFIG_EXTENSION = dev;

--- a/ios/mapswipe/Info.plist
+++ b/ios/mapswipe/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.6</string>
+	<string>2.2.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>1</string>
 	<key>GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_PERSONALIZATION_SIGNALS</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED</key>

--- a/ios/mapswipeTests/Info.plist
+++ b/ios/mapswipeTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.6</string>
+	<string>2.2.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>1</string>
 </dict>
 </plist>

--- a/ios/mapswipeUITests/Info.plist
+++ b/ios/mapswipeUITests/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.6</string>
+	<string>2.2.7</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>1</string>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mapswipe",
-  "version": "2.2.6",
-  "build": "7",
+  "version": "2.2.7",
+  "build": "1",
   "private": true,
   "scripts": {
     "buildDev": "cd android && ./gradlew assembleDevRelease && cd ..",


### PR DESCRIPTION
@laurentS I am following the certificate update process from [here.](https://github.com/mapswipe/mapswipe/blob/master/docs/develop-ios.md#renewing-ios-certificates)
Some problems I encountered

1. I couldn't get the `apple appstore / appstore login for app upload` password as suggested on the number 2 of the above link. 
2. I don't have the necessary permission to set `FASTLANE_SESSION` env variable for gh actions as well.
3. It seems I need to login to `developer.apple.com` to do the number 3. Right now I don't have it.
4. I don't have the permission to edit `https://gitlab.com/mapswipe/ios-certificates/-/settings/repository#js-deploy-keys-settings` it as well. 
5. The [CI](https://github.com/mapswipe/mapswipe/actions/runs/6807940693/job/18549585799) is failing. Could you kindly examine and confirm whether the error is a result of the conditions mentioned above not being met?

I apologize for the lengthy message, and I appreciate you taking the time to review these matters.

