### PR TITLE
fix: add username validation with simple Regex

### DIFF
--- a/__tests__/common/Username.js
+++ b/__tests__/common/Username.js
@@ -1,0 +1,21 @@
+import { isValidUsername } from '../../src/shared/utils';
+
+test('Check that username validation denies and accepts expected usernames', () => {
+    const checks = [
+        { in: 'BilboBaggins', out: true },
+        { in: 'TimBillyBob93', out: true },
+        { in: 'Dan_TheMan15', out: true },
+        { in: '  Spacer  ', out: false },
+        { in: 'AfterSpacer ', out: false },
+        { in: 'Mid Spacer 15', out: false },
+        { in: '5ymb0! F4N 1983!', out: false },
+        { in: 'ithinkits@email.com', out: false },
+        { in: '', out: false },
+        { in: ' ', out: false },
+        { in: '     ', out: false },
+    ];
+    checks.forEach(check => {
+        const res = isValidUsername(check.in);
+        expect(res).toEqual(check.out);
+    });
+});

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -258,3 +258,8 @@ export function getTimeSegments(
         lastState,
     );
 }
+
+export function isValidUsername(username: String): Boolean {
+    const re = new RegExp('^[a-zA-Z0-9_]+$', 'g');
+    return re.test(username);
+}

--- a/src/shared/views/ChangeUserName.js
+++ b/src/shared/views/ChangeUserName.js
@@ -18,6 +18,7 @@ import {
 import PageHeader from '../common/PageHeader';
 import Button from '../common/Button';
 import type { NavigationProp, TranslationFunction } from '../flow-types';
+import { isValidUsername } from '../utils';
 
 const styles = StyleSheet.create({
     changeUserNameScreen: {
@@ -87,7 +88,7 @@ function ChangeUserName(props: Props) {
     const [updatePending, setUpdatePending] = React.useState(false);
 
     const handleConfirmButtonClick = React.useCallback(() => {
-        if ((newUserName?.length ?? 0) >= MIN_USERNAME_LENGTH) {
+        if (isValidUsername(newUserName)) {
             setUpdatePending(true);
             firebase
                 .updateAuth({ displayName: newUserName })

--- a/src/shared/views/Login.js
+++ b/src/shared/views/Login.js
@@ -30,6 +30,7 @@ import {
     devOsmUrl,
     MIN_USERNAME_LENGTH,
 } from '../constants';
+import { isValidUsername } from '../utils';
 
 /* eslint-disable global-require */
 
@@ -199,15 +200,6 @@ class _Login extends React.Component<Props, State> {
         const { firebase, navigation, t } = this.props;
         const { email, password, username } = this.state;
         const parent = this;
-        if (username !== null && username.length < MIN_USERNAME_LENGTH) {
-            MessageBarManager.showAlert({
-                title: t('signup:errorOnSignup'),
-                message: t('signup:usernameErrorMessage'),
-                alertType: 'error',
-                shouldHideAfterDelay: false,
-            });
-            return;
-        }
 
         if (username !== null && username.indexOf('@') !== -1) {
             MessageBarManager.showAlert({
@@ -218,6 +210,17 @@ class _Login extends React.Component<Props, State> {
             });
             return;
         }
+
+        if (!isValidUsername(username)) {
+            MessageBarManager.showAlert({
+                title: t('signup:errorOnSignup'),
+                message: t('signup:usernameErrorMessage'),
+                alertType: 'error',
+                shouldHideAfterDelay: false,
+            });
+            return;
+        }
+
         this.setState({
             loadingNext: true,
         });


### PR DESCRIPTION
- Addresses #639 
- Adds unit test to assert standard validation rules (letters, numbers and underscores. No special symbols or spaces.)
- Moves the email-in-username check to before the main validation check so the specialized message can still appear.