### PR TITLE
Add device type on mapping

### DIFF
--- a/src/shared/actions/index.js
+++ b/src/shared/actions/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { actionTypes } from 'react-redux-firebase';
-import { getVersion } from 'react-native-device-info';
+import { getVersion, getSystemName } from 'react-native-device-info';
 
 import type { ResultMapType, ResultType, State } from '../flow-types';
 import GLOBAL from '../Globals';
@@ -223,6 +223,9 @@ export function commitGroup(groupInfo: GroupInfo): ThunkAction {
         // get a single timestamp upon completion of the group
         const endTime = GLOBAL.DB.getTimestamp();
         const appVersion = getVersion();
+        const systemName = getSystemName().toLowerCase(); // ios or android
+        const clientType = systemName ? `mobile-${systemName}` : 'mobile';
+
         const { groupId, projectId, results } = groupInfo;
         dispatch(startSendingResults(projectId, groupId));
         const { startTime, ...rest } = results[projectId][groupId];
@@ -231,6 +234,7 @@ export function commitGroup(groupInfo: GroupInfo): ThunkAction {
             endTime,
             results: rest,
             appVersion,
+            clientType,
         };
         const fbPath = `v2/results/${projectId}/${groupId}/${userId}/`;
         firebase

--- a/src/shared/common/AccessibilityInfoModal.js
+++ b/src/shared/common/AccessibilityInfoModal.js
@@ -125,7 +125,7 @@ function AccessibilityInfoModal() {
             <View style={styles.row}>
                 <Image source={QuestionMarkIcon} style={styles.image} />
                 <Text style={styles.text}>
-                    <Trans i18nKey="AccessibilityInstruction:tickIconInfo">
+                    <Trans i18nKey="AccessibilityInstruction:questionMarkIconInfo">
                         Tap twice to turn the tile yellow and show a question
                         icon
                     </Trans>
@@ -134,7 +134,7 @@ function AccessibilityInfoModal() {
             <View style={styles.row}>
                 <Image source={BadImageIcon} style={styles.image} />
                 <Text style={styles.text}>
-                    <Trans i18nKey="AccessibilityInstruction:tickIconInfo">
+                    <Trans i18nKey="AccessibilityInstruction:badImageIconInfo">
                         Tap thrice to turn the tile red and show a bad imagery
                         icon
                     </Trans>


### PR DESCRIPTION
### Addresses:

- https://github.com/mapswipe/mapswipe/issues/873
- https://github.com/mapswipe/mapswipe/issues/882

### Changes
- Fix accessibility modal instructions
- Add system name on mapping (eg: `clientType: android`)

### Changes
- Fix accessibility modal instructions